### PR TITLE
Update time and file metadata parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/files.py
+++ b/files.py
@@ -56,6 +56,8 @@ class FileService:
         router.register(self.__description_packet, 0x69)
         router.register(self.__block_packet, 0x18)
         router.register(self.__fec_packet, 0xff)
+        router.register(self.__signaling_packet, 0x42)
+        router.register(self.__signaling_packet, 0x5a)
 
         self.__files = dict()
         self.__files_path = files_path
@@ -111,6 +113,16 @@ class FileService:
         if file_id in self.__files:
             f = self.__files[file_id]
             f.push_fec(block, block_number)
+
+    def __signaling_packet(self, packet):
+        """
+        File signaling packet handler
+
+        Args:
+          packet (LDP): the LDP packet to handle
+        """
+        print('[File service] Received signaling information (not implemented yet)')
+        # TODO Update file dictionary based on signed, deflated XML
 
     def __try_reconstruct(self, file_id):
         """

--- a/timeservice.py
+++ b/timeservice.py
@@ -43,7 +43,7 @@ class TimeService:
         Args:
           router (LDPRouter): LDP router to get packets from
         """
-        router.register(self.__get, 0x8100, 0x0104)
+        router.register(self.__get, 0x81)
 
     def __get(self, packet):
         """


### PR DESCRIPTION
First of all, thank you for your amazing work! Before your 33C3 talk, I never heard of this interesting technology.

I did some digging in the supplied binaries and discovered that LDP packets actually only have a 4-byte header and packets length are 24-bit instead of 16-bit wide. This in turn makes decoding file metadata and time packets much easier. The time packets seem to contain some kind of variable-length record structure.