### PR TITLE
Implement error-correcting OP defragmenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Things that are not implemented/supported yet:
    automatically. This is easy to implement, but it is low on my priority list,
    as it is very easy to do this manually.
 
+## Dependencies
+
+To install all dependencies just run: `pip install -r requirements.txt`
+
+ * [zfec](https://pypi.python.org/pypi/zfec)
+
 ## Sample KISS files
 
 You can use some [sample KISS files](https://drive.google.com/open?id=0B2pPGQkeEAfdbXFZNThCb1BLMzg) for testing.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Things that are not implemented/supported yet:
 
 To install all dependencies just run: `pip install -r requirements.txt`
 
+ * [crcmod](https://pypi.python.org/pypi/crcmod)
  * [zfec](https://pypi.python.org/pypi/zfec)
 
 ## Sample KISS files

--- a/files.py
+++ b/files.py
@@ -1,15 +1,15 @@
 # Copyright 2016 Daniel Estevez <daniel@destevez.net>.
-# 
+#
 # This is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3, or (at your option)
 # any later version.
-# 
+#
 # This software is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this software; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
@@ -44,7 +44,7 @@ class FileService:
     using the File() class
     """
     __block_header_len = 6
-    
+
     def __init__(self, router, files_path):
         """
         Initialize file service handler
@@ -143,7 +143,7 @@ class FileService:
         out.close()
         del self.__files[file_id]
         print('[File service] File reconstructed: {}'.format(f.path))
-        
+
 
 class File:
     """
@@ -194,7 +194,7 @@ class File:
         if self.__fec_blocks[n]:
             raise ValueError('File.push_fec(): FEC block already received!')
         self.__fec_blocks[n] = block
-    
+
     def reconstruct(self):
         """
         Try to reconstruct the file
@@ -213,7 +213,7 @@ class File:
                 fec = bytes().join(self.__fec_blocks)
                 print('Length of FEC data: {} bytes; File size: {} bytes'.format(len(fec), self.size))
             print('--------------------------------------------------------------------')
-        
+
         if None in self.__blocks:
             print('Some blocks are missing. Cannot reconstruct file {}'.format(self.path))
             return

--- a/free-outernet.py
+++ b/free-outernet.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright 2016 Daniel Estevez <daniel@destevez.net>.
-# 
+#
 # This is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3, or (at your option)
@@ -11,7 +11,7 @@
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this software; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
@@ -44,7 +44,7 @@ ETHERTYPE = b'\x8f\xff'
 
 def printMac(mac):
     return ('%02x:'* 5 + '%02x') % struct.unpack('B'*6, mac)
-    
+
 def printEthertype(ethertype):
     return hex(struct.unpack('>H', ethertype)[0])
 
@@ -105,7 +105,7 @@ def usage():
 \t-p, --port=PORT\t\tUDP port to listen (default {})
 \t    --host=HOST\t\tUDP host to listen (default ::, use 0.0.0.0 for IPv4 only)
 '''.format(UDP_PORT))
-    
+
 
 def main():
     try:
@@ -146,7 +146,7 @@ def main():
 
     timeservice.TimeService(router)
     files.FileService(router, output)
-    
+
     if kissinput:
         kissFile = open(kissinput, 'rb')
         kissDeframer = kiss.KISSDeframer()

--- a/kiss.py
+++ b/kiss.py
@@ -1,15 +1,15 @@
 # Copyright 2016 Daniel Estevez <daniel@destevez.net>.
-# 
+#
 # This is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3, or (at your option)
 # any later version.
-# 
+#
 # This software is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this software; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
@@ -33,7 +33,7 @@ class KISSDeframer():
     __FESC = 0xdb
     __TFEND = 0xdc
     __TFESC = 0xdd
-    
+
     def __init__(self):
         """
         Initialize KISS deframer
@@ -53,9 +53,9 @@ class KISSDeframer():
           data (bytes): the chunk of bytes to push
         """
         pdus = list()
-        
+
         self.__kiss.extend(data)
-        
+
         while self.__kiss:
             c = self.__kiss.popleft()
             if c == self.__FEND:

--- a/protocols.py
+++ b/protocols.py
@@ -1,20 +1,20 @@
 # Copyright 2016 Daniel Estevez <daniel@destevez.net>.
-# 
+#
 # This is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3, or (at your option)
 # any later version.
-# 
+#
 # This software is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this software; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,
 # Boston, MA 02110-1301, USA.
-# 
+#
 
 """Outernet OP and LDP protocols"""
 
@@ -223,7 +223,7 @@ class LDPRouter:
         Create a new LDP router
         """
         self.__registrations = dict()
-        
+
     def route(self, packet):
         """
         Push an LDP packet into the router, calling the appropriate

--- a/protocols.py
+++ b/protocols.py
@@ -27,6 +27,7 @@ __email__ = 'daniel@destevez.net'
 
 import struct
 import zfec
+from crcmod.predefined import PredefinedCrc
 
 class OP:
     """
@@ -205,8 +206,10 @@ class LDP:
         if self.length > len(data):
             raise ValueError('Malformed LDP packet: invalid length')
 
-        self.checksum = data[self.length-self.__checksum_len:self.length]
-        # TODO implement checksum handling
+        crc = PredefinedCrc('crc-32-mpeg')
+        crc.update(data[:self.length])
+        if crc.crcValue != 0:
+            raise ValueError('Malformed LDP packet: invalid checksum')
 
         self.payload = data[self.__header_len:self.length-self.__checksum_len]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+crcmod>=1.7,<2
 git+https://github.com/george-hopkins/pyutil@python3#egg=pyutil
 git+https://github.com/george-hopkins/zfec@python3#egg=zfec

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/george-hopkins/pyutil@python3#egg=pyutil
+git+https://github.com/george-hopkins/zfec@python3#egg=zfec

--- a/timeservice.py
+++ b/timeservice.py
@@ -1,15 +1,15 @@
 # Copyright 2016 Daniel Estevez <daniel@destevez.net>.
-# 
+#
 # This is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 3, or (at your option)
 # any later version.
-# 
+#
 # This software is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this software; see the file COPYING.  If not, write to
 # the Free Software Foundation, Inc., 51 Franklin Street,


### PR DESCRIPTION
During my research, I discovered that some LDP packets (mostly file metadata) are sent with additional FEC data (not the same as file block FEC). The error-correcting scheme is based on Vandermonde matrices. To implement the decoder I used the library [zfec](https://github.com/tahoe-lafs/zfec). To ensure the decoder works correctly, LDP checksums are verified.

With this change, the decoding process up to layer 4 should be identical to what's done in ondd 2.2.0. When checked against the KISS samples, both implementations give the same results (excluding file block reconstruction).

At the moment, zfec is not yet compatible with Python 3. However, there is an pending PR (tahoe-lafs/zfec#4). It's up to you if you'd like to wait for a release. In the meantime, you can pull the necessary changes from my branch (see `requirements.txt`).
