### PR TITLE
Implement FEC for files

### DIFF
--- a/files.py
+++ b/files.py
@@ -325,14 +325,12 @@ class File:
         """
         Generate pseudo random numbers
 
+        Implementation of the Park-Miller random number generator
+
         Args:
           seed (int): Seed
         """
         value = seed
         while True:
-            value = ((16807 * (value >> 16) >> 15)
-                + ((16807 * (value >> 16) & 0x7fff) << 16)
-                + (16807 * (value & 0xffff)))
-            if value & 0x80000000:
-                value -= 0x7fffffff
+            value = (7**5 * value) % (2**31 - 1)
             yield value


### PR DESCRIPTION
This patch implements a FEC decoder for files (based on ondd v2.2.0). As I don't have any knowledge about LDPC codes, the implementation is most probably non-optimal (I'm not even sure whether it's actually a LDPC code or they just named it `ldpc` :wink:).

The decoder mimics the same behaviour as ondd: If a file is reconstructable for sure, do it. If not, wait until a new file starts and no new packets are expected to be received. If you want to decode a file as soon as possible, you might want to try to reconstruct earlier. When tested with the four KISS samples, ondd and this implementation seem show the same behaviour.

In case there is already a library which implements such a decoder, I'm happy to incorporate it and ditch my own implementation (same goes for the PRNG).