### PR TITLE
Use official releases of dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 crcmod>=1.7,<2
-git+https://github.com/george-hopkins/pyutil@python3#egg=pyutil
-git+https://github.com/george-hopkins/zfec@python3#egg=zfec
+zfec>=1.5,<2


### PR DESCRIPTION
Support for Python 3 has landed for the dependencies pyutil and zfec. Now, we can use the official releases. The decoder works the same way as before.